### PR TITLE
CMake configuration tuning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,8 +149,10 @@ add_subdirectory(src/lib)
 # Install binaries and headers
 # =============================================================================
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/src/include/ DESTINATION include)
-install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/iv-config.cmake DESTINATION share/cmake/iv/)
-install(EXPORT iv DESTINATION share/cmake/iv)
+if(NOT IV_AS_SUBPROJECT)
+  install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/cmake/iv-config.cmake DESTINATION share/cmake)
+  install(EXPORT iv DESTINATION share/cmake)
+endif()
 
 # =============================================================================
 # Print build status

--- a/cmake/iv-config.cmake
+++ b/cmake/iv-config.cmake
@@ -1,0 +1,8 @@
+# iv-config.cmake - package configuration file
+
+get_filename_component(CONFIG_PATH "${CMAKE_CURRENT_LIST_FILE}" PATH)
+
+find_path(IV_INCLUDE_DIR "ivversion.h" HINTS "${CONFIG_PATH}/../../include")
+find_path(IV_LIB_DIR NAMES libinterviews.a libinterviews.so libinterviews.dylib HINTS "${CONFIG_PATH}/../../lib")
+
+include(${CONFIG_PATH}/iv.cmake)

--- a/iv-config.cmake
+++ b/iv-config.cmake
@@ -1,8 +1,0 @@
-# iv-config.cmake - package configuration file
-
-get_filename_component(CONFIG_PATH "${CMAKE_CURRENT_LIST_FILE}" PATH)
-
-find_path(iv_INCLUDE "ivversion.h" HINTS "${CONFIG_PATH}/../../../include")
-find_path(iv_LIB NAMES libinterviews.a libinterviews.so libinterviews.dylib HINTS "${CONFIG_PATH}/../../../lib")
-
-include(${CONFIG_PATH}/iv.cmake)


### PR DESCRIPTION
  - avoid installing iv-config if project is being installed as
    subproject. Otherwise CMake of neuron finds it as external project
    when building second time
  - change share/cmake/iv to share/cmake to avoid directory
    specification for every project