### PR TITLE
Define libUnidraw dep on libIV

### DIFF
--- a/src/lib/Makefile.in
+++ b/src/lib/Makefile.in
@@ -74,7 +74,7 @@ libIV_la_LDFLAGS = -version-info 3:3:0 $(X_LDFLAGS)
 libIV_la_LIBADD = $(X_LIBS)
 
 libUnidraw_la_LDFLAGS = -version-info 3:3:0 $(X_LDFLAGS)
-libUnidraw_la_LIBADD = $(X_LIBS)
+libUnidraw_la_LIBADD = $(libIV) $(X_LIBS) 
 
 #
 # Lists of objects that go into the libraries:
@@ -472,7 +472,7 @@ uninstall:
 $(libIV): $(libIV_la_OBJECTS) $(libIV_la_DEPENDENCIES)
 	$(CXXLINK) -rpath $(libdir) $(libIV_la_LDFLAGS) $(libIV_la_OBJECTS) $(libIV_la_LIBADD) $(MINGW_LIBS) $(LIBS)
 
-$(libUnidraw): $(libUnidraw_la_OBJECTS) $(libUnidraw_la_DEPENDENCIES)
+$(libUnidraw): $(libUnidraw_la_OBJECTS) $(libUnidraw_la_DEPENDENCIES) $(libIV)
 	$(CXXLINK) -rpath $(libdir) $(libUnidraw_la_LDFLAGS) $(libUnidraw_la_OBJECTS) $(libUnidraw_la_LIBADD) $(LIBS)
 
 


### PR DESCRIPTION
The [package review for NeuroFedora](https://bugzilla.redhat.com/show_bug.cgi?id=1150441#c11) suggests that libUnidraw is underlinked: it should be linked against libIVhines. This PR modifies the makefile to do so.

This is what `rpmlint` documentation says:

```
$ rpmlint -I undefined-non-weak-symbol
undefined-non-weak-symbol:
The binary contains undefined non-weak symbols.  This may indicate improper
linkage; check that the binary has been linked as expected.

```

These are the `rpmlnt` warnings:

```
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 typeinfo for ivResource
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivResource::ref() const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivResource::unref() const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivResource::unref_deferred() const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivResource::cleanup()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 typeinfo for iv2_6_Dialog
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 typeinfo for ivStringChooser
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 typeinfo for iv2_6_FileChooser
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 typeinfo for ivButtonState
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivInteractor::request(ivRequisition&) const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivInteractor::allocate(ivCanvas*, ivAllocation const&, ivExtension&)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivInteractor::draw(ivCanvas*, ivAllocation const&) const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivGlyph::print(ivPrinter*, ivAllocation const&) const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivInteractor::pick(ivCanvas*, ivAllocation const&, int, ivHit&)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivInteractor::undraw()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivGlyph::clone() const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivGlyph::compose(unsigned int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivGlyph::append(ivGlyph*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivGlyph::prepend(ivGlyph*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivGlyph::insert(long, ivGlyph*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivGlyph::remove(long)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivGlyph::replace(long, ivGlyph*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivGlyph::change(long)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivGlyph::count() const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivGlyph::component(long) const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivGlyph::allotment(long, unsigned int, ivAllotment&) const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivMonoScene::Reconfig()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivInteractor::Reshape(ivShape&)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivMonoScene::GetComponents(ivInteractor**, int, ivInteractor**&, int&)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivMonoScene::Draw()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivScene::Highlight(bool)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivInteractor::Handle(ivEvent&)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivInteractor::Adjust(ivPerspective&)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivInteractor::Update()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivInteractor::Redraw(int, int, int, int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivInteractor::RedrawList(int, int*, int*, int*, int*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivMonoScene::Resize()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivInteractor::Activate()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivInteractor::Deactivate()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivScene::Orphan()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivScene::Wrap(ivInteractor*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivMonoScene::DoInsert(ivInteractor*, bool, int&, int&)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivMonoScene::DoChange(ivInteractor*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivScene::DoMove(ivInteractor*, int&, int&)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivMonoScene::DoRemove(ivInteractor*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivScene::DoRaise(ivInteractor*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivScene::DoLower(ivInteractor*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 iv2_6_Dialog::Accept()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 iv2_6_Dialog::Popup(ivEvent&, bool)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivStringChooser::Handle(ivEvent&)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivStringChooser::Accept()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivStringChooser::Choice()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivStringChooser::SwitchFocus()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivStringChooser::CanFocus(ivInteractor*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivStringChooser::HandleFocus()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivStringChooser::UpdateEditor()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivStringChooser::UpdateBrowser()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 typeinfo for ivSubject
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivSubject::Attach(ivInteractor*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivSubject::Detach(ivInteractor*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivSubject::Notify()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivSubject::IsView(ivInteractor*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 iv2_6_FileChooser::Update()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 iv2_6_FileChooser::Accept()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 typeinfo for ivInputHandler
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivMonoGlyph::request(ivRequisition&) const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivInputHandler::allocate(ivCanvas*, ivAllocation const&, ivExtension&)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivInputHandler::draw(ivCanvas*, ivAllocation const&) const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivMonoGlyph::print(ivPrinter*, ivAllocation const&) const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivInputHandler::pick(ivCanvas*, ivAllocation const&, int, ivHit&)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivInputHandler::undraw()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivMonoGlyph::append(ivGlyph*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivMonoGlyph::prepend(ivGlyph*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivMonoGlyph::insert(long, ivGlyph*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivMonoGlyph::remove(long)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivMonoGlyph::replace(long, ivGlyph*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivMonoGlyph::change(long)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivMonoGlyph::count() const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivMonoGlyph::component(long) const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivMonoGlyph::allotment(long, unsigned int, ivAllotment&) const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivMonoGlyph::body(ivGlyph*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivMonoGlyph::body() const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivInputHandler::handler() const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivInputHandler::parent() const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivInputHandler::style() const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivInputHandler::append_input_handler(ivInputHandler*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivInputHandler::remove_input_handler(long)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivInputHandler::remove_all_input_handlers()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivInputHandler::input_handler_count() const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivInputHandler::input_handler(long) const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivInputHandler::focus(ivInputHandler*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivInputHandler::next_focus()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivInputHandler::prev_focus()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivInputHandler::move(ivEvent const&)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivInputHandler::press(ivEvent const&)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivInputHandler::drag(ivEvent const&)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivInputHandler::release(ivEvent const&)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivInputHandler::double_click(ivEvent const&)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivInputHandler::focus_in()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivInputHandler::focus_out()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivInputHandler::allocation_changed(ivCanvas*, ivAllocation const&)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivInputHandler::inside(ivEvent const&)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivInputHandler::canvas() const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivInputHandler::transformer() const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivInputHandler::allocation() const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivInputHandler::redraw() const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivInputHandler::repick(int, ivHit&)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 typeinfo for ivInteractor
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivInteractor::Reconfig()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivInteractor::GetComponents(ivInteractor**, int, ivInteractor**&, int&)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivInteractor::Orphan()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 typeinfo for ivSlidingEllipse
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 typeinfo for ivRubberband
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivRubberband::Redraw()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivRubberband::Erase()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivRubberband::Track(int, int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivRubberband::SetPainter(ivPainter*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivRubberband::SetCanvas(ivCanvas*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivRubberEllipse::GetOriginal(int&, int&, int&, int&)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivSlidingEllipse::GetCurrent(int&, int&, int&, int&)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivSlidingEllipse::OriginalRadii(int&, int&)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivSlidingEllipse::CurrentRadii(int&, int&)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 typeinfo for ivBrush
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 typeinfo for ivColor
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 typeinfo for ivFont
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 typeinfo for ivPattern
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivBrush::width() const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivBrush::dash_count() const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivBrush::dash_list(int) const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivColor::distinguished(ivDisplay*, ivColor const*) const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivColor::intensities(ivDisplay*, float&, float&, float&) const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivColor::alpha() const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivColor::op() const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivColor::brightness(float) const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivFont::cleanup()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivFont::name() const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivFont::encoding() const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivFont::size() const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivFont::font_bbox(ivFontBoundingBox&) const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivFont::char_bbox(long, ivFontBoundingBox&) const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivFont::string_bbox(char const*, int, ivFontBoundingBox&) const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivFont::width(long) const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivFont::width(char const*, int) const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivFont::index(char const*, int, float, bool) const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 typeinfo for ivMonoScene
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivInteractor::Draw()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivInteractor::Highlight(bool)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivInteractor::Resize()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 typeinfo for ivControl
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivControl::Handle(ivEvent&)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivControl::Enable(bool)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivControl::Select()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivControl::Unselect()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivControl::Do()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivControl::Down()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivControl::Enter()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivControl::Open()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivControl::Grab()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivControl::Skip()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivControl::Leave()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivControl::Close()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivControl::Up()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivControl::Busy()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivControl::Done()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivControl::IsGrabbing(ivInteractor*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivinch
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 noEvents
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivcm
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivpoints
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 updownEvents
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 vtable for ivRubberEllipse
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivinches
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 allEvents
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivTextDisplay::AddStyle(int, int, int, int, int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivSensor::Catch(unsigned int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivTransformer::InvTransformList(int*, int*, int, int*, int*) const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivCanvas::Height() const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivTransformer::translate(float, float)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivSensor::ivSensor()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivInteractor::Listen(ivSensor*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 iv2_6_FileChooser::UpdateEditor()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivStringEditor::ivText()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivTextBuffer::BeginningOfNextLine(int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivResource::unref(ivResource const*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 iv2_6_Dialog::~iv2_6_Dialog()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivScene::Insert(ivInteractor*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivButtonState::~ivButtonState()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivFont::Width(char const*) const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivTransformer::~ivTransformer()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivBrush::Width() const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivPerspective::operator!=(ivPerspective&)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivHBox::ivHBox(ivInteractor*, ivInteractor*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivScalingLine::CurrentScaling()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivTarget::ivTarget(ivGlyph*, TargetSensitivity)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivGrowingClosedBSpline::ivGrowingClosedBSpline(ivPainter*, ivCanvas*, int*, int*, int, int, int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivInteractor::SetClassName(char const*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivTextBuffer::BeginningOfWord(int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivResource::ivResource()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivMessage::ivMessage(char const*, unsigned int, int, int, int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 iv2_6_FileChooser::iv2_6_FileChooser(ivButtonState*, char const*, int, int, unsigned int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 iv2_6_DownMover::iv2_6_DownMover(ivInteractor*, int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivTextDisplay::Height()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivSession::style() const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 iv2_6_VScroller::iv2_6_VScroller(ivInteractor*, int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivPerspective::Update()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivStringBrowser::ivStringBrowser(ivButtonState*, int, int, bool, int, char const*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivRotatingLine::ivRotatingLine(ivPainter*, ivCanvas*, int, int, int, int, int, int, int, int, int, int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivBitmap::Bottom() const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivRubberEllipse::ivRubberEllipse(ivPainter*, ivCanvas*, int, int, int, int, int, int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivTransformer::ivTransformer(ivTransformer const*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivTextDisplay::InsertText(int, int, char const*, int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivTextDisplay::Base(int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivPerspective::~ivPerspective()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivTextBuffer::EndOfPreviousWord(int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivTextDisplay::DeleteLinesAfter(int, int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivStringEditor::ivStringEditor(ivButtonState*, char const*, char const*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivInteractor::SetCanvasType(CanvasType)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivTextDisplay::Redraw(int, int, int, int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivStringChooser::~ivStringChooser()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivTextDisplay::Top(int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivFont::exists(ivDisplay*, char const*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivInteractor::GetCursor() const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivTransformer::TransformRect(int&, int&, int&, int&) const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivPainter::FillBg(bool)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivSubject::Notify()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivVBox::ivVBox(ivInteractor*, ivInteractor*, ivInteractor*, ivInteractor*, ivInteractor*, ivInteractor*, ivInteractor*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivTextDisplay::DeleteText(int, int, int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivShape::Rect(int, int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 iv2_6_FileChooser::Init(char const*, char const*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivTransformer::InvTransformRect(float&, float&, float&, float&) const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivDialogKit::instance()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivStringEditor::ivMessage(char const*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivTextBuffer::EndOfLine(int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivTextBuffer::Insert(int, char const*, int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivTextBuffer::LineOffset(int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivHBox::ivHBox(ivInteractor*, ivInteractor*, ivInteractor*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivRotatingLineList::OriginalAngle()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivRotatingLineList::CurrentAngle()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivScalingRect::ivScalingRect(ivPainter*, ivCanvas*, int, int, int, int, int, int, int, int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivStyle::ivStyle(ivStyle*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivStringChooser::SelectMessage()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivInteractor::SetInstance(char const*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivTIFFRaster::load(char const*, bool)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivTransformer::Transform(int&, int&) const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivResource::ref(ivResource const*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivStringChooser::ivStringChooser(ivButtonState*, int, int, char const*, unsigned int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivInteractor::UnRead(ivEvent&)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivTextDisplay::CaretStyle(int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivTextDisplay::~ivTextDisplay()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivGrowingBSpline::ivGrowingBSpline(ivPainter*, ivCanvas*, int*, int*, int, int, int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivTextDisplay::LineNumber(int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivTextBuffer::ivTextBuffer(char*, int, int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivFont::Width(char const*, int) const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivResource::~ivResource()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivEvent::ivEvent()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivTransformer::operator==(ivTransformer const&) const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 iv2_6_HGlue::iv2_6_HGlue(int, int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivPainter::ivPainter()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivInputHandler::ivInputHandler(ivGlyph*, ivStyle*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivFont::ivFont(char const*, float)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivRotatingLine::OriginalAngle()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivTextDisplay::RemoveStyle(int, int, int, int, int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivStringBrowser::osString(int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivGrowingPolygon::ivGrowingPolygon(ivPainter*, ivCanvas*, int*, int*, int, int, int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivStringChooser::ivMessage(char const*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivSensor::ivSensor(ivSensor const*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivTextBuffer::EndOfWord(int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivTextDisplay::InsertLinesAfter(int, int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivRubberband::~ivRubberband()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 iv2_6_Dialog::iv2_6_Dialog(char const*, ivButtonState*, ivInteractor*, unsigned int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivPainter::GetFont() const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivWorld::current()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivPainter::SetPattern(ivPattern const*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivInteractor::ivInteractor()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivPattern::ivPattern(int const*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivPainter::SetFont(ivFont const*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivTextDisplay::Right(int, int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivBitmap::ivBitmap(void const*, unsigned int, unsigned int, int, int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivStringEditor::Select(int, int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivTextDisplay::ivTextDisplay(bool)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivTextDisplay::Bounds(int&, int&, int&, int&)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 iv2_6_Dialog::iv2_6_Dialog(ivButtonState*, ivInteractor*, unsigned int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivRubberGroup::ivRubberGroup(ivPainter*, ivCanvas*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivSlidingLine::ivSlidingLine(ivPainter*, ivCanvas*, int, int, int, int, int, int, int, int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivMonoScene::ivMonoScene()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivTextBuffer::BeginningOfLine(int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivPainter::ivPainter(ivPainter*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivMonoScene::Reconfig()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivWorld::ivWorld(char const*, int&, char**, ivOptionDesc const*, ivPropertyData const*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivTransformer::ivTransformer(float, float, float, float, float, float)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivRubberLine::ivRubberLine(ivPainter*, ivCanvas*, int, int, int, int, int, int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivBrush::ivBrush(float)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivTransformer::invert()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivPainter::GetFgColor() const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivInteractor::Poll(ivEvent&)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivHBox::ivHBox(ivInteractor*, ivInteractor*, ivInteractor*, ivInteractor*, ivInteractor*, ivInteractor*, ivInteractor*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivMarginFrame::ivMarginFrame(ivInteractor*, int, int, int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivButtonState::SetValue(int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivControl::SetState(ivControlState*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ListImpl_range_error(long)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivBrush::~ivBrush()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivGrowingMultiLine::ivGrowingMultiLine(ivPainter*, ivCanvas*, int*, int*, int, int, int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivTextDisplay::LineHeight(int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 __AnyPtrList::~__AnyPtrList()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivControl::~ivControl()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivTextBuffer::LineIndex(int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivTransformer::InvTransform(int, int, int&, int&) const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivStringChooser::ivStringChooser(ivButtonState*, unsigned int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 iv2_6_FileChooser::SetTitle(char const*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivTextBuffer::LineNumber(int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivButtonState::ivButtonState()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivScalingRect::CurrentScaling()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivTransformer::operator=(ivTransformer const&)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivPainter::GetTransformer() const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivTextBuffer::EndOfPreviousLine(int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivScalingLineList::ivScalingLineList(ivPainter*, ivCanvas*, int*, int*, int, int, int, int, int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivEvent::operator=(ivEvent const&)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivStyle::attribute(char const*, char const*, int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivTransformer::postmultiply(ivTransformer const&)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivPainter::BgFilled() const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivStyle::alias(char const*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 iv2_6_PushButton::iv2_6_PushButton(char const*, ivButtonState*, int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivTransientWindow::ivTransientWindow(ivGlyph*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivTextDisplay::ReplaceText(int, char const*, int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivSession::instance()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 iv2_6_VGlue::iv2_6_VGlue(int, int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 iv2_6_FileChooser::UpdateBrowser()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivSlidingRect::ivSlidingRect(ivPainter*, ivCanvas*, int, int, int, int, int, int, int, int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivVBox::ivVBox(ivInteractor*, ivInteractor*, ivInteractor*, ivInteractor*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivTransformer::TransformRect(float&, float&, float&, float&) const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivButtonState::ivButtonState(int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivBitmap::open(char const*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 iv2_6_FileChooser::AddScroller(ivInteractor*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivStretchingRect::ivStretchingRect(ivPainter*, ivCanvas*, int, int, int, int, Side, int, int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivColor::ivColor(float, float, float, float, unsigned int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivRubberRect::ivRubberRect(ivPainter*, ivCanvas*, int, int, int, int, int, int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivEvent::~ivEvent()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivRaster::ivRaster(unsigned long, unsigned long)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivFrame::ivFrame(ivInteractor*, int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivButtonState::ivButtonState(int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 osNullTerminatedString::osNullTerminatedString(osString const&)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivInteractor::Read(ivEvent&)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivSlidingLineList::ivSlidingLineList(ivPainter*, ivCanvas*, int*, int*, int, int, int, int, int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 __AnyPtrList::remove(long)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivCanvas::Width() const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 __AnyPtrList::__AnyPtrList(long)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivTextBuffer::BeginningOfNextWord(int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivControl::ivControl(char const*, ivInteractor*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivStringBrowser::Remove(int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivTextDisplay::Draw(ivPainter*, ivCanvas*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivScalingLine::ivScalingLine(ivPainter*, ivCanvas*, int, int, int, int, int, int, int, int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivTransformer::operator!=(ivTransformer const&) const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivBitmap::Left() const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 __AnyPtrList::insert(long, void* const&)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivControl::ivControl(ivInteractor*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivStringBrowser::Insert(char const*, int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivTransformer::ivTransformer()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 iv2_6_FileChooser::~iv2_6_FileChooser()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivTextDisplay::Width()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 osMemory::copy(void const*, void*, unsigned int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivApplicationWindow::ivApplicationWindow(ivGlyph*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivPainter::GetBgColor() const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivFont::~ivFont()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivRubberHandles::ivRubberHandles(ivPainter*, ivCanvas*, int*, int*, int, int, int, int, int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivBitmap::ivBitmap(ivBitmap const&)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivPerspective::ivPerspective(ivPerspective&)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivRubberGroup::First()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivScalingLineList::CurrentScaling()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivHBox::ivHBox(ivInteractor*, ivInteractor*, ivInteractor*, ivInteractor*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivPainter::SetBrush(ivBrush const*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivTransformer::Transform(int, int, int&, int&) const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivTransformer::TransformList(int*, int*, int, int*, int*) const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivStringChooser::Init(ivStringEditor*, ivStringBrowser*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivStringBrowser::Index(char const*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivRotatingRect::CurrentAngle()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivHBox::ivHBox(ivInteractor*, ivInteractor*, ivInteractor*, ivInteractor*, ivInteractor*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivTextDisplay::Left(int, int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivScene::Change(ivInteractor*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivRotatingRect::ivRotatingRect(ivPainter*, ivCanvas*, int, int, int, int, int, int, int, int, int, int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivVBox::ivVBox(ivInteractor*, ivInteractor*, ivInteractor*, ivInteractor*, ivInteractor*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivColor::find(ivDisplay const*, char const*, float&, float&, float&)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 osMemory::zero(void*, unsigned int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivStringEditor::Edit()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivPattern::~ivPattern()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivTextDisplay::Resize(int, int, int, int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 osNullTerminatedString::~osNullTerminatedString()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivBrush::calc_dashes(int, int*, int&)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivPainter::SetColors(ivColor const*, ivColor const*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 iv2_6_UpMover::iv2_6_UpMover(ivInteractor*, int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivStyle::name(char const*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivPerspective::operator=(ivPerspective&)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivMonoScene::~ivMonoScene()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivRotatingLine::CurrentAngle()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivColor::~ivColor()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivTextDisplay::LineIndex(int, int, bool)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivVBorder::ivVBorder(int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivRotatingLineList::ivRotatingLineList(ivPainter*, ivCanvas*, int*, int*, int, int, int, int, int, int, int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivPainter::MoveTo(int, int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivBrush::ivBrush(int, float)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 osMemory::compare(void const*, void const*, unsigned int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivShape::Rigid(int, int, int, int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivMarginFrame::ivMarginFrame(ivInteractor*, int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivRubberband::ivRubberband(ivPainter*, ivCanvas*, int, int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivTextDisplay::Caret(int, int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivStringBrowser::Clear()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivPattern::ivPattern(int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivTextBuffer::~ivTextBuffer()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivTransformer::InvTransform(int&, int&) const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivHBorder::ivHBorder(int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivFont::Height() const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivRubberGroup::Append(ivRubberband*, ivRubberband*, ivRubberband*, ivRubberband*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivInteractor::~ivInteractor()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivControl::RootControl()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivSlidingEllipse::ivSlidingEllipse(ivPainter*, ivCanvas*, int, int, int, int, int, int, int, int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivPerspective::ivPerspective()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivMatchEditor::ivMatchEditor(ivButtonState*, char const*, char const*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivVBox::ivVBox(ivInteractor*, ivInteractor*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivTransformer::Transform(float, float, float&, float&) const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivTransformer::InvTransform(float, float, float&, float&) const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivPainter::SetTransformer(ivTransformer*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivInteractor::GetWorld() const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivRaster::ivRaster(ivRaster const&)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivEvent::handle()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivInputHandler::~ivInputHandler()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivTextDisplay::TabWidth(int)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivTransformer::TransformList(int*, int*, int) const
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivInteractor::SetCursor(ivCursor*)
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 ivWidgetKit::instance()
iv.x86_64: W: undefined-non-weak-symbol /usr/lib64/libUnidrawhines.so.3.0.3 iv2_6_RadioButton::iv2_6_RadioButton(char const*, ivButtonState*, int)
```
