### PR TITLE
Set CMAKE_BUILD_TYPE to be a cached var defaulting to RelWithDebInfo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,9 @@ option(IV_ENABLE_SHARED "Build libraries shared or static" OFF)
 # =============================================================================
 # CMake build settings
 # =============================================================================
-set(CMAKE_BUILD_TYPE Debug)
+set(CMAKE_BUILD_TYPE
+        RelWithDebInfo
+        CACHE STRING "Empty or one of Debug, Release, RelWithDebInfo")
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bin)
 
 if(NOT IV_ENABLE_SHARED)


### PR DESCRIPTION
A very minor fix that helps propagating compiler options correctly across the different units when building NEURON.