### PR TITLE
PREPEND instead of APPEND to the CMAKE_MODULE_PATH.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ endif()
 # =============================================================================
 # Include cmake modules
 # =============================================================================
-list(APPEND CMAKE_MODULE_PATH ${IV_PROJECT_SOURCE_DIR}/cmake)
+list(PREPEND CMAKE_MODULE_PATH ${IV_PROJECT_SOURCE_DIR}/cmake)
 include(HelperFunctions)
 include(PlatformHelper)
 include(RpathHelper)


### PR DESCRIPTION
Otherwise, if iv is used as a submodule for nrn, IV_WINDOWS_BUILD will not be set for windows.