### PR TITLE
PREPEND iv/cmake to the CMAKE_MODULE_PATH.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ endif()
 # =============================================================================
 # Include cmake modules
 # =============================================================================
-list(PREPEND CMAKE_MODULE_PATH ${IV_PROJECT_SOURCE_DIR}/cmake)
+list(INSERT CMAKE_MODULE_PATH 0 ${IV_PROJECT_SOURCE_DIR}/cmake)
 include(HelperFunctions)
 include(PlatformHelper)
 include(RpathHelper)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ endif()
 # =============================================================================
 # Include cmake modules
 # =============================================================================
-list(APPEND CMAKE_MODULE_PATH ${IV_PROJECT_SOURCE_DIR}/cmake)
+list(PREPEND CMAKE_MODULE_PATH ${IV_PROJECT_SOURCE_DIR}/cmake)
 include(HelperFunctions)
 include(PlatformHelper)
 include(RpathHelper)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,9 @@ endif()
 # =============================================================================
 # Include cmake modules
 # =============================================================================
+# Prepend to CMAKE_MODULE_PATH since iv/cmake/PlatformHelper.cmake
+# sets IV_WINDOWS_BUILD. Otherwise, as a submodule for nrn,
+# nrn/cmake/PlatformHelper.cmake would take precedence.
 list(INSERT CMAKE_MODULE_PATH 0 ${IV_PROJECT_SOURCE_DIR}/cmake)
 include(HelperFunctions)
 include(PlatformHelper)


### PR DESCRIPTION
When iv is a submodule it needs to include its own PlatformHelper.