### PR TITLE
Fix conflict with nrn PlatformHelper.cmake when iv is a submodule.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,8 @@ endif()
 # =============================================================================
 list(APPEND CMAKE_MODULE_PATH ${IV_PROJECT_SOURCE_DIR}/cmake)
 include(HelperFunctions)
-include(PlatformHelper)
+# do not conflict with nrn PlatformHelper.cmake when submodule.
+include(${IV_PROJECT_SOURCE_DIR}/cmake/PlatformHelper.cmake)
 include(RpathHelper)
 include(CheckIncludeFiles)
 include(CheckFunctionExists)


### PR DESCRIPTION
Per suggestions from nrn repository issue 406, when a submodule include conflicts with a
supermodule file, use a full path to the submodule include.