### PR TITLE
Tweaks related to installation of shared objects on Linux systems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,11 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "CYGWIN")
   set(CYGWIN 1)
 endif()
 
+# set up libdir
+if(NOT DEFINED LIB_INSTALL_DIR)
+    set(LIB_INSTALL_DIR ${CMAKE_INSTALL_PREFIX}/lib)
+endif()
+
 # =============================================================================
 # Include cmake modules
 # =============================================================================
@@ -186,8 +191,8 @@ add_subdirectory(src/bin)
 # =============================================================================
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/src/include/ DESTINATION include)
 if(NOT IV_AS_SUBPROJECT)
-  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/cmake/iv-config.cmake DESTINATION share/cmake)
-  install(EXPORT iv DESTINATION share/cmake)
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/cmake/iv-config.cmake DESTINATION ${LIB_INSTALL_DIR}/cmake/iv)
+    install(EXPORT iv DESTINATION ${LIB_INSTALL_DIR}/cmake/iv)
 endif()
 
 # =============================================================================

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -413,6 +413,9 @@ set_property(TARGET interviews PROPERTY POSITION_INDEPENDENT_CODE ON)
 if(IV_WINDOWS_BUILD)
   target_link_libraries(interviews gdi32 comdlg32)
 endif()
+if(NOT IV_WINDOWS_BUILD)
+    set_target_properties(interviews PROPERTIES SOVERSION 0.0.0)
+endif()
 
 # =============================================================================
 # ivx11dynam
@@ -477,6 +480,7 @@ endif()
 if(NOT IV_WINDOWS_BUILD)
   if(IV_ENABLE_SHARED)
     add_library(unidraw SHARED ${UNIDRAW_SOURCE_FILES})
+    set_target_properties(unidraw PROPERTIES SOVERSION 0.0.0)
   else()
     add_library(unidraw STATIC ${UNIDRAW_SOURCE_FILES})
   endif()

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -496,12 +496,12 @@ install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/app-defaults/ DESTINATION share/ap
 if(NOT IV_WINDOWS_BUILD)
   install(TARGETS interviews
           EXPORT iv
-          DESTINATION lib
+          DESTINATION ${LIB_INSTALL_DIR}
           INCLUDES
           DESTINATION $<INSTALL_INTERFACE:include>)
   install(TARGETS unidraw
           EXPORT iv
-          DESTINATION lib
+          DESTINATION ${LIB_INSTALL_DIR}
           INCLUDES
           DESTINATION $<INSTALL_INTERFACE:include>)
 else()


### PR DESCRIPTION
- Adds a SOVERSION to the generated shared objects: since none is defined, I've just used `0.0.0`.
- use `LIB_INSTALL_DIR` instead of hardcoding `lib`. On 64 bit Linux systems, this allows one to install to `/usr/lib64` as per the filesystem hierarchy standard.
- Also updates the relevant bits to install the exported cmake files to the correct `lib{,64}/cmake/iv` folder