### PR TITLE
Fix build issue with Apple clang version 12.0.0 (clang-1200.0.32.2)

### DIFF
--- a/src/lib/IV-2_6/tray.cpp
+++ b/src/lib/IV-2_6/tray.cpp
@@ -37,8 +37,6 @@
 
 #include <IV-2_6/_enter.h>
 
-inline float abs (float f) { return (f < 0) ? -f : f; }
-
 /*************************************************************************/
 
 class TElement {


### PR DESCRIPTION
	- removed inconsistent definition of abs() method which is not used
	  anyway