### PR TITLE
Allow Custom build type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ option(IV_ENABLE_X11_DYNAMIC_MAKE_HEADERS "Remake the X11 dynamic .h files." OFF
 # =============================================================================
 # CMake build settings
 # =============================================================================
-set(allowableBuildTypes Debug Release RelWithDebInfo)
+set(allowableBuildTypes Custom Debug Release RelWithDebInfo)
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE
       RelWithDebInfo


### PR DESCRIPTION
This is useful if you want e.g. an `-O1 -g` build.