### PR TITLE
Hines/sprintf typo

### DIFF
--- a/src/lib/IV-Win/session.cpp
+++ b/src/lib/IV-Win/session.cpp
@@ -881,7 +881,7 @@ void SessionRep::load_path(
 {
     String h(head);
     String t(tail);
-    auto z = strlen(head) + strlen(tail) + 1;
+    auto sz = strlen(head) + strlen(tail) + 1;
     char* buff = new char[sz];
     snprintf(buff, sz, "%s%s", head, tail);
     load_file(s, buff, priority);

--- a/src/lib/OS/directory.cpp
+++ b/src/lib/OS/directory.cpp
@@ -673,7 +673,7 @@ void DirectoryImpl::do_fill() {
 void DirectoryImpl::do_fill() {
 	 WIN32_FIND_DATA fd;
     HANDLE h;
-         auto sz = strlen(name->string()) + 3;
+         auto sz = strlen(name_->string()) + 3;
 	 char * buf = new char[sz];
 	 snprintf(buf, sz, "%s%s", name_->string(), "*");
 	 for (h = FindFirstFile(buf, &fd); FindNextFile(h, &fd);) {


### PR DESCRIPTION
with this the neuronsimulator/nrn#2105 CI passes (in particular on Windows).