### PR TITLE
Avoid function pointers of unspecified arguments

### DIFF
--- a/src/lib/TIFF/tif_cmprs.c
+++ b/src/lib/TIFF/tif_cmprs.c
@@ -83,11 +83,7 @@ extern	int TIFFInitJPEG();
 struct cscheme {
 	char*	name;
 	int	scheme;
-#if USE_PROTOTYPES
 	int	(*init)(TIFF*);
-#else
-	int	(*init)();
-#endif
 };
 static const struct cscheme CompressionSchemes[] = {
     { "Null",		COMPRESSION_NONE,	TIFFInitDumpMode },

--- a/src/lib/TIFF/tif_cmprs.c
+++ b/src/lib/TIFF/tif_cmprs.c
@@ -83,7 +83,11 @@ extern	int TIFFInitJPEG();
 struct cscheme {
 	char*	name;
 	int	scheme;
+#if USE_PROTOTYPES
+	int	(*init)(TIFF*);
+#else
 	int	(*init)();
+#endif
 };
 static const struct cscheme CompressionSchemes[] = {
     { "Null",		COMPRESSION_NONE,	TIFFInitDumpMode },

--- a/src/lib/TIFF/tif_getimage.c
+++ b/src/lib/TIFF/tif_getimage.c
@@ -139,7 +139,7 @@ static	int gtTileContig(TIFF*, u_long*, RGBvalue*, u_long, u_long);
 static	int gtTileSeparate(TIFF*, u_long*, RGBvalue*, u_long, u_long);
 static	int gtStripContig(TIFF*, u_long*, RGBvalue*, u_long, u_long);
 static	int gtStripSeparate(TIFF*, u_long*, RGBvalue*, u_long, u_long);
-static	void initYCbCrConversion();
+static	void initYCbCrConversion(void);
 
 static
 int gt(tif, w, h, raster)
@@ -1000,7 +1000,7 @@ static	float D1, D2;
 static	float D3, D4;
 
 static void
-initYCbCrConversion()
+initYCbCrConversion(void)
 {
 	D1 = 2 - 2*LumaRed;
 	D2 = D1*LumaRed / LumaGreen;

--- a/src/lib/TIFF/tif_getimage.c
+++ b/src/lib/TIFF/tif_getimage.c
@@ -58,11 +58,7 @@ static	float *refBlackWhite;
 static	u_long **BWmap;
 static	u_long **PALmap;
 
-#if USE_PROTOTYPES
 static	int gt(TIFF*, int, int, u_long*);
-#else
-static	int gt();
-#endif
 static int makebwmap(RGBvalue *Map);
 static int makecmap(u_short *rmap, ushort *gmap, ushort *bmap);
 
@@ -139,17 +135,10 @@ checkcmap(n, r, g, b)
 	return (8);
 }
 
-#if USE_PROTOTYPES
 static	int gtTileContig(TIFF*, u_long*, RGBvalue*, u_long, u_long);
 static	int gtTileSeparate(TIFF*, u_long*, RGBvalue*, u_long, u_long);
 static	int gtStripContig(TIFF*, u_long*, RGBvalue*, u_long, u_long);
 static	int gtStripSeparate(TIFF*, u_long*, RGBvalue*, u_long, u_long);
-#else
-static	int gtTileContig();
-static	int gtTileSeparate();
-static	int gtStripContig();
-static	int gtStripSeparate();
-#endif
 static	void initYCbCrConversion();
 
 static

--- a/src/lib/TIFF/tif_getimage.c
+++ b/src/lib/TIFF/tif_getimage.c
@@ -58,7 +58,11 @@ static	float *refBlackWhite;
 static	u_long **BWmap;
 static	u_long **PALmap;
 
+#if USE_PROTOTYPES
+static	int gt(TIFF*, int, int, u_long*);
+#else
 static	int gt();
+#endif
 static int makebwmap(RGBvalue *Map);
 static int makecmap(u_short *rmap, ushort *gmap, ushort *bmap);
 
@@ -135,10 +139,17 @@ checkcmap(n, r, g, b)
 	return (8);
 }
 
+#if USE_PROTOTYPES
+static	int gtTileContig(TIFF*, u_long*, RGBvalue*, u_long, u_long);
+static	int gtTileSeparate(TIFF*, u_long*, RGBvalue*, u_long, u_long);
+static	int gtStripContig(TIFF*, u_long*, RGBvalue*, u_long, u_long);
+static	int gtStripSeparate(TIFF*, u_long*, RGBvalue*, u_long, u_long);
+#else
 static	int gtTileContig();
 static	int gtTileSeparate();
 static	int gtStripContig();
 static	int gtStripSeparate();
+#endif
 static	void initYCbCrConversion();
 
 static

--- a/src/lib/TIFF/tiffioP.h
+++ b/src/lib/TIFF/tiffioP.h
@@ -251,6 +251,20 @@ struct tiff {
 	int 	tif_curtile;		/* current tile for read/write */
 	long 	tif_tilesize;		/* # of bytes in a tile */
 /* compression scheme hooks */
+#if USE_PROTOTYPES
+	int	(*tif_predecode)(TIFF*);			/* pre row/strip/tile decoding */
+	int	(*tif_preencode)(TIFF*);			/* pre row/strip/tile encoding */
+	int	(*tif_postencode)(TIFF*);			/* post row/strip/tile encoding */
+	int	(*tif_decoderow)(TIFF*, u_char*, int, u_int);	/* scanline decoding routine */
+	int	(*tif_encoderow)(TIFF*, u_char*, int, u_int);	/* scanline encoding routine */
+	int	(*tif_decodestrip)(TIFF*, u_char*, int, u_int);	/* strip decoding routine */
+	int	(*tif_encodestrip)(TIFF*, u_char*, int, u_int);	/* strip encoding routine */
+	int	(*tif_decodetile)(TIFF*, u_char*, int, u_int);	/* tile decoding routine */
+	int	(*tif_encodetile)(TIFF*, u_char*, int, u_int);	/* tile encoding routine */
+	int	(*tif_close)(TIFF*);				/* cleanup-on-close routine */
+	int	(*tif_seek)(TIFF *, int);			/* position within a strip routine */
+	int	(*tif_cleanup)(TIFF*);				/* routine called to cleanup state */
+#else
 	int	(*tif_predecode)();	/* pre row/strip/tile decoding */
 	int	(*tif_preencode)();	/* pre row/strip/tile encoding */
 	int	(*tif_postencode)();	/* post row/strip/tile encoding */
@@ -263,6 +277,7 @@ struct tiff {
 	int	(*tif_close)();		/* cleanup-on-close routine */
 	int	(*tif_seek)();		/* position within a strip routine */
 	int	(*tif_cleanup)();	/* routine called to cleanup state */
+#endif
 	char	*tif_data;		/* compression scheme private data */
 /* input/output buffering */
 	int	tif_scanlinesize;	/* # of bytes in a scanline */

--- a/src/lib/TIFF/tiffioP.h
+++ b/src/lib/TIFF/tiffioP.h
@@ -251,7 +251,6 @@ struct tiff {
 	int 	tif_curtile;		/* current tile for read/write */
 	long 	tif_tilesize;		/* # of bytes in a tile */
 /* compression scheme hooks */
-#if USE_PROTOTYPES
 	int	(*tif_predecode)(TIFF*);			/* pre row/strip/tile decoding */
 	int	(*tif_preencode)(TIFF*);			/* pre row/strip/tile encoding */
 	int	(*tif_postencode)(TIFF*);			/* post row/strip/tile encoding */
@@ -264,20 +263,6 @@ struct tiff {
 	int	(*tif_close)(TIFF*);				/* cleanup-on-close routine */
 	int	(*tif_seek)(TIFF *, int);			/* position within a strip routine */
 	int	(*tif_cleanup)(TIFF*);				/* routine called to cleanup state */
-#else
-	int	(*tif_predecode)();	/* pre row/strip/tile decoding */
-	int	(*tif_preencode)();	/* pre row/strip/tile encoding */
-	int	(*tif_postencode)();	/* post row/strip/tile encoding */
-	int	(*tif_decoderow)();	/* scanline decoding routine */
-	int	(*tif_encoderow)();	/* scanline encoding routine */
-	int	(*tif_decodestrip)();	/* strip decoding routine */
-	int	(*tif_encodestrip)();	/* strip encoding routine */
-	int	(*tif_decodetile)();	/* tile decoding routine */
-	int	(*tif_encodetile)();	/* tile encoding routine */
-	int	(*tif_close)();		/* cleanup-on-close routine */
-	int	(*tif_seek)();		/* position within a strip routine */
-	int	(*tif_cleanup)();	/* routine called to cleanup state */
-#endif
 	char	*tif_data;		/* compression scheme private data */
 /* input/output buffering */
 	int	tif_scanlinesize;	/* # of bytes in a scanline */


### PR DESCRIPTION
As of C23 (the default standard in GCC 15), `int foo()` is interpreted as a nullary function like `int foo(void)`, as it would be in C++, rather than as a function of unspecified arguments.

This PR adjusts some code in the bundled libtiff that still expects to be able to declare and use a function pointer without bothering to specify its arguments.

With these changes, I was able to build `iv` in Fedora Rawhide (the development version of the distribution) with a GCC 15 pre-release in C23 mode.